### PR TITLE
Remove redundant clone of updated markers in adjustMarkersOnInsert.

### DIFF
--- a/src/interval-skip-list.coffee
+++ b/src/interval-skip-list.coffee
@@ -229,7 +229,7 @@ class IntervalSkipList
     newPromoted = []
 
     for i in [0...(node.height - 1)]
-      for marker in clone(updated[i].markers[i])
+      for marker in updated[i].markers[i]
         [startIndex, endIndex] = @intervalsByMarker[marker]
         if @compare(node.next[i + 1].index, endIndex) <= 0
           @removeMarkerOnPath(marker, node.next[i], node.next[i + 1], i)


### PR DESCRIPTION
We don't need to clone updated[i].markers[i] in phase 1 because it is not
updated.
